### PR TITLE
fix: replace Github with GitHub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ Pull requests are the best way to propose changes to the codebase and we activel
 5. Push changes to your fork
 6. Open a PR in our [repository](https://github.com/motcodes/recommends/pulls)
 
-## Report bugs using Github's [issues](https://github.com/motcodes/recommends/issues)
+## Report bugs using GitHub's [issues](https://github.com/motcodes/recommends/issues)
 
 We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/motcodes/recommends/issues/new/choose); it's that easy!
 

--- a/content/git/index.mdx
+++ b/content/git/index.mdx
@@ -1,12 +1,12 @@
 ---
-title: Git & Github
-tags: [Git, Version Control, Github]
+title: Git & GitHub
+tags: [Git, Version Control, GitHub]
 image: /recommends-git-and-github-cover.png
 chapter: 9
 icon: 🌳
 ---
 
-When your are on this website then you should already know the basics of Git and Github/Gitlab.
+When your are on this website then you should already know the basics of Git and GitHub/Gitlab.
 But only for the sake of completeness, here is the dry definition of Git:  
 Git is a version control system that is used to manage changes to files.
 It is a distributed version control system that tracks changes to files, such as the addition of a new file or the deletion of an existing file.
@@ -21,7 +21,7 @@ As a designer, I recommend to learn Git via using the GUI. The GUI is more user 
 
 Since hopefully everybody knows `git add` and `git commit`, I will not go into detail about them.
 
-- Github Education - [Git Cheatsheet](https://education.github.com/git-cheat-sheet-education.pdf)
+- GitHub Education - [Git Cheatsheet](https://education.github.com/git-cheat-sheet-education.pdf)
 - [Useful Git Commands](https://dev.to/lydiahallie/cs-visualized-useful-git-commands-37p1) - by [Lydia Hallie](https://dev.to/lydiahallie)
 - [Git Handbook](https://guides.github.com/introduction/git-handbook/)
 
@@ -34,20 +34,20 @@ and for quick access:
   height="600px"
 />
 
-## Working with Github
+## Working with GitHub
 
-- [Github Help](https://help.github.com/)
-- [Github - Hello World](https://guides.github.com/activities/hello-world/)
-- [Github - Forking](https://guides.github.com/activities/forking/)
+- [GitHub Help](https://help.github.com/)
+- [GitHub - Hello World](https://guides.github.com/activities/hello-world/)
+- [GitHub - Forking](https://guides.github.com/activities/forking/)
 - [How to Contribute to a Git Repository](https://www.youtube.com/watch?v=HbSjyU2vf6Y) - Video Version
 - [/recommends Contribute Guide](https://github.com/motcodes/recommends/blob/main/CONTRIBUTING.md)
 - [Mastering Issues](https://guides.github.com/features/issues/)
 
 ## Git GUIs
 
-- [Git Kraken](https://www.gitkraken.com/) - which I recommend and if you are in the Github Student Programme, you can use it for free.
-- [Github Desktop](https://desktop.github.com/)
+- [Git Kraken](https://www.gitkraken.com/) - which I recommend and if you are in the GitHub Student Programme, you can use it for free.
+- [GitHub Desktop](https://desktop.github.com/)
 - [SourceTree](https://www.sourcetreeapp.com/)
-- [Github](https://github.com/) via the Browser
+- [GitHub](https://github.com/) via the Browser
 - [Gitlab](https://gitlab.com/) via the Browser
 - [GitLens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens) - Visual Studio Code extension

--- a/content/learning/index.mdx
+++ b/content/learning/index.mdx
@@ -78,7 +78,7 @@ buy single course or subscribe for one new course every month
 #### All Frontend Masters courses
 
 by various lecturers  
-a monthly subscription is $39.99. With the Github Student Package you get access to all courses for free for 6 months.
+a monthly subscription is $39.99. With the GitHub Student Package you get access to all courses for free for 6 months.
 [Link](https://www.leveluptutorials.com/)
 
 #### All Awwwards courses


### PR DESCRIPTION
- Improve spelling by replacing `Github` with `GitHub` on the Markdown files.